### PR TITLE
Push OCI helm chart to `manics/oci-helm-charts`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,10 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  CHART_REPOSITORY: ${{ github.repository }}
+  # Pushing images and OCI Helm charts to the same GHCR package doesn't work
+  # properly (Helm chart remains private), so use a different package repository
+  # for the Helm chart.
+  CHART_REPOSITORY: ${{ github.repository_owner }}/oci-helm-charts
   PLATFORMS: linux/amd64,linux/arm64
 
 jobs:


### PR DESCRIPTION
For some reason the helm chart in https://github.com/manics/binderhub-container-registry-helper/pkgs/container/binderhub-container-registry-helper seems to be hidden/private, the containers are public though