### PR TITLE
Switch to GitHub pages for Helm chart

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,6 @@ on:
   push:
   pull_request:
 
-permissions:
-  contents: read
-  packages: write
-
 env:
   REGISTRY: quay.io
   IMAGE_NAME: ${{ github.repository }}
@@ -70,8 +66,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        # with:
-        #   fetch-depth: 0
 
       - name: Docker meta
         id: meta
@@ -94,11 +88,6 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
-      - name: Login to OCI Helm chart registry
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo ${{ secrets.REGISTRY_TOKEN }} | helm registry login --username ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.REGISTRY }}
-
       - name: Build and push to container registry
         uses: docker/build-push-action@v4
         with:
@@ -110,8 +99,59 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
 
-      - name: Package and push Helm chart
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+  helmchart:
+    permissions:
+      contents: write
+    needs:
+      - container
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Build chart
         run: |
           make helm
+
+      - name: Login to OCI Helm chart registry
+        run: |
+          echo ${{ secrets.REGISTRY_TOKEN }} | helm registry login --username ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.REGISTRY }}
+
+      - name: Push Helm chart to quay.io
+        run: |
           helm push binderhub-container-registry-helper-*.tgz oci://${{ env.REGISTRY }}/${{ env.CHART_REPOSITORY }}
+
+      - name: Add chart to gh-pages
+        run: |
+          shopt -s nullglob
+          filename=(binderhub-container-registry-helper-*.tgz)
+          if [ -z "$filename" ]; then
+            echo "No chart found"
+            exit 1
+          fi
+          if [ -f "gh-pages/$filename" ]; then
+            echo "Chart $filename already exists"
+            exit 1
+          fi
+          mv "$filename" gh-pages/
+          helm repo index gh-pages/
+
+      - name: Commit gh-pages
+        run: |
+          git config user.name github-chart-bot
+          git config user.email "github-chart-bot@users.noreply.github.com"
+          git add --all
+          git commit -m "Update chart"
+        working-directory: gh-pages
+
+      - name: Push gh-pages
+        run: |
+          git push origin gh-pages
+        working-directory: gh-pages

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ This repository includes an OCI Helm chart to deploy this service to a Kubernete
 Deploy the OCI Helm chart, see [`Values.yaml`](./helm-chart/values.yaml) for configuration options.
 
 ```
-helm show chart oci://quay.io/manics/helm-charts/binderhub-container-registry-helper
+helm repo add binderhub-container-registry-helper https://www.manicstreetpreacher.co.uk/binderhub-container-registry-helper/
 
-helm upgrade binderhub-container-registry-helper oci://quay.io/manics/helm-charts/binderhub-container-registry-helper --version <VERSION>
+helm upgrade binderhub-container-registry-helper/binderhub-container-registry-helper --version <VERSION>
 ```
 
 Append this example [BinderHub configuration](binderhub-example/binderhub_config.py) to your BinderHub `extraConfig` section.


### PR DESCRIPTION
quay.io has rate limits, which means downstream GH CI jobs timeout.

I've manually initialised the `gh-pages` branch with the existing chart versions.